### PR TITLE
fix:css:email link color in speaker slides

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,5 @@ demo/libs
 
 #Mac
 .DS_Store
+
+.vscode

--- a/README.md
+++ b/README.md
@@ -127,10 +127,14 @@ This theme use target for [RevealJS](https://revealjs.com/#/) so all you can do 
 <h2> Jean-François<span> Garreau</span></h2>
 
 ### CTO front
-<!-- .element: classs="icon-rule icon-first" -->
+<!-- .element: class="icon-rule icon-first" -->
 
 ### @jefbinomed
-<!-- .element: classs="icon-twitter icon-second" -->
+<!-- .element: class="icon-twitter icon-second" -->
+
+### fake.email@sfeir.com
+
+<!-- .element: class="icon-mail icon-third" -->
 ```
 
 ![](./assets/speaker-slide.png)

--- a/demo/md/01_speaker.md
+++ b/demo/md/01_speaker.md
@@ -22,6 +22,10 @@
 ### @jefbinomed
 <!-- .element: class="icon-twitter icon-second" -->
 
+### fake.email@sfeir.com
+
+<!-- .element: class="icon-mail icon-third" -->
+
 ##--##
 
 <!-- .slide: class="with-code" -->
@@ -48,6 +52,9 @@
 <!-- .element: class="icon-twitter icon-second" -->
 ```
 
+### fake.email@sfeir.com
+
+<!-- .element: class="icon-mail icon-third" -->
 
 ##==##
 
@@ -68,6 +75,10 @@
 
 ### @jefbinomed
 <!-- .element: class="icon-twitter icon-second" -->
+
+### fake.email@sfeir.com
+
+<!-- .element: class="icon-mail icon-third" -->
 
 ##--##
 
@@ -93,6 +104,10 @@
 
 ### @jefbinomed
 <!-- .element: class="icon-twitter icon-second" -->
+
+### fake.email@sfeir.com
+
+<!-- .element: class="icon-mail icon-third" -->
 ```
 
 
@@ -116,6 +131,10 @@
 ### @jefbinomed
 <!-- .element: class="icon-twitter icon-second" -->
 
+### fake.email@sfeir.com
+
+<!-- .element: class="icon-mail icon-third" -->
+
 ##--##
 
 <!-- .slide: class="with-code" -->
@@ -140,4 +159,8 @@
 
 ### @jefbinomed
 <!-- .element: class="icon-twitter icon-second" -->
+
+### fake.email@sfeir.com
+
+<!-- .element: class="icon-mail icon-third" -->
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1231,7 +1231,8 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -1249,11 +1250,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -1266,15 +1269,18 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -1377,7 +1383,8 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -1387,6 +1394,7 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -1399,17 +1407,20 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -1426,6 +1437,7 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -1498,7 +1510,8 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -1508,6 +1521,7 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -1583,7 +1597,8 @@
         },
         "safe-buffer": {
           "version": "5.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -1613,6 +1628,7 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -1630,6 +1646,7 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -1668,11 +1685,13 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         }
       }
     },

--- a/src/scss/theme/speaker-slide.scss
+++ b/src/scss/theme/speaker-slide.scss
@@ -1,3 +1,5 @@
+@import "./colors.scss";
+
 .reveal  .slides section[data-background].speaker-slide{
     height: 800px; // force a big height to avoid strange operations 
     text-transform: inherit;
@@ -69,14 +71,17 @@
         content: '\ec98';
     }
 
-    h3.icon-mail:before{
+    h3.icon-mail:before {
         content: '\e8c8';
+    }
+
+    h3[class^=icon]>a {
+        color: white;
     }
 
     h3.icon-rule:before{
         content: '\e81d';
     }
-    
 
     img[alt*=speaker]{
         position: absolute;


### PR DESCRIPTION
In speaker slides h3 titles with class icon-mail links appear dark as ".reveal a" tells.
Made it white.